### PR TITLE
Python 3 + use unique temp directory for each run

### DIFF
--- a/nginx-server.py
+++ b/nginx-server.py
@@ -64,7 +64,7 @@ def main():
     with open(conf, "w") as f:
         conf_data = conf_template % dict(root=root, port=port)
         f.write(conf_data)
-    print >>sys.stderr, "%r serving in %r" % (root, address)
+    print("%r serving in %r" % (root, address), file=sys.stderr)
     os.execvp("nginx", ["nginx", "-c", conf])
 
 main()


### PR DESCRIPTION
- fix syntax to run on Python 3
- allow multiple concurrent runs by using a unique directory made by `mkdtemp`